### PR TITLE
Trim newlines on attributed strings

### DIFF
--- a/Highball.xcodeproj/project.pbxproj
+++ b/Highball.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		40A11E6B19B51FF700B91843 /* ImageCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40A11E6A19B51FF700B91843 /* ImageCollectionViewCell.swift */; };
 		40B609531A99234B0089E431 /* BlogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40B609521A99234B0089E431 /* BlogViewController.swift */; };
 		40C78D1519BD29330002EB78 /* ReblogTransitionAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40C78D1419BD29330002EB78 /* ReblogTransitionAnimator.swift */; };
+		40CE13D91CB3377100847A94 /* NSAttributedString+Trim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40CE13D81CB3377100847A94 /* NSAttributedString+Trim.swift */; };
 		40CFDAB41C344931008FBF9A /* HeightCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40CFDAB31C344931008FBF9A /* HeightCalculator.swift */; };
 		40CFDAB61C34990F008FBF9A /* ReuseIdentifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40CFDAB51C34990F008FBF9A /* ReuseIdentifiers.swift */; };
 		40CFDAB81C349F84008FBF9A /* TextReblogTableViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40CFDAB71C349F84008FBF9A /* TextReblogTableViewAdapter.swift */; };
@@ -119,6 +120,7 @@
 		40A11E6A19B51FF700B91843 /* ImageCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCollectionViewCell.swift; sourceTree = "<group>"; };
 		40B609521A99234B0089E431 /* BlogViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlogViewController.swift; sourceTree = "<group>"; };
 		40C78D1419BD29330002EB78 /* ReblogTransitionAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReblogTransitionAnimator.swift; sourceTree = "<group>"; };
+		40CE13D81CB3377100847A94 /* NSAttributedString+Trim.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+Trim.swift"; sourceTree = "<group>"; };
 		40CFDAB31C344931008FBF9A /* HeightCalculator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeightCalculator.swift; sourceTree = "<group>"; };
 		40CFDAB51C34990F008FBF9A /* ReuseIdentifiers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReuseIdentifiers.swift; sourceTree = "<group>"; };
 		40CFDAB71C349F84008FBF9A /* TextReblogTableViewAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextReblogTableViewAdapter.swift; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 			children = (
 				4008591A1B7EBA05009DF207 /* NSDate+Relative.swift */,
 				40CFDAB51C34990F008FBF9A /* ReuseIdentifiers.swift */,
+				40CE13D81CB3377100847A94 /* NSAttributedString+Trim.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -616,6 +619,7 @@
 				40CFDAB61C34990F008FBF9A /* ReuseIdentifiers.swift in Sources */,
 				402033591A6C785400BA136C /* AnimatedImageCache.swift in Sources */,
 				40731BBA19FDCAD300F6978D /* LikesViewController.swift in Sources */,
+				40CE13D91CB3377100847A94 /* NSAttributedString+Trim.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Highball/ContentTableViewCell.swift
+++ b/Highball/ContentTableViewCell.swift
@@ -65,11 +65,11 @@ class ContentTableViewCell: WCFastCell, DTAttributedTextContentViewDelegate {
 		didSet {
 			if let content = content {
 				let data = content.dataUsingEncoding(NSUTF8StringEncoding)
-				let stringBuilderOptions = [DTDefaultHeadIndent: 0, DTDefaultFirstLineHeadIndent: 0]
+				let stringBuilderOptions = [DTDefaultHeadIndent: 0, DTDefaultFirstLineHeadIndent: 0, DTDocumentPreserveTrailingSpaces: false, DTUseiOS6Attributes: true]
 				let htmlStringBuilder = DTHTMLAttributedStringBuilder(HTML: data, options: stringBuilderOptions, documentAttributes: nil)
-				let attributedString = htmlStringBuilder.generatedAttributedString()
+				let attributedString = htmlStringBuilder.generatedAttributedString().attributedStringByTrimmingNewlines()
 				contentTextView.attributedString = attributedString
-				usernameLabel.superview?.hidden = (content.characters.count == 0)
+				usernameLabel.superview?.hidden = (attributedString.string.characters.count == 0)
 			} else {
 				contentTextView.attributedString = NSAttributedString(string: "")
 				usernameLabel.superview?.hidden = true
@@ -103,7 +103,6 @@ class ContentTableViewCell: WCFastCell, DTAttributedTextContentViewDelegate {
 		avatarImageView.clipsToBounds = true
 		avatarImageView.contentMode = .ScaleAspectFit
 		avatarImageView.layer.cornerRadius = 4
-		avatarImageView.backgroundColor = UIColor.redColor()
 
 		usernameLabel.font = UIFont.boldSystemFontOfSize(16)
 		usernameLabel.textColor = UIColor.whiteColor()

--- a/Highball/HeightCalculator.swift
+++ b/Highball/HeightCalculator.swift
@@ -53,8 +53,8 @@ struct HeightCalculator {
 			return
 		}
 
-		let attributedString = NSAttributedString(HTMLData: data, options: [DTDefaultHeadIndent: 0, DTDefaultFirstLineHeadIndent: 0], documentAttributes: nil)
-		let layouter = DTCoreTextLayouter(attributedString: attributedString)
+		let attributedString = NSAttributedString(HTMLData: data, options: [DTDefaultHeadIndent: 0, DTDefaultFirstLineHeadIndent: 0, DTDocumentPreserveTrailingSpaces: false, DTUseiOS6Attributes: true], documentAttributes: nil)
+		let layouter = DTCoreTextLayouter(attributedString: attributedString.attributedStringByTrimmingNewlines())
 		let maxRect = CGRect(x: 0, y: 0, width: width - 20, height: CGFloat(CGFLOAT_HEIGHT_UNKNOWN))
 		// swiftlint:disable legacy_constructor
 		let entireString = NSMakeRange(0, attributedString.length)
@@ -62,7 +62,7 @@ struct HeightCalculator {
 		let layoutFrame = layouter.layoutFrameWithRect(maxRect, range: entireString)
 
 		dispatch_async(dispatch_get_main_queue()) {
-			completion(height: ceil(layoutFrame.frame.height) + 34)
+			completion(height: ceil(layoutFrame.frame.height + 32))
 		}
 	}
 }

--- a/Highball/NSAttributedString+Trim.swift
+++ b/Highball/NSAttributedString+Trim.swift
@@ -1,0 +1,22 @@
+//
+//  NSAttributedString+Trim.swift
+//  Highball
+//
+//  Created by Ian Ynda-Hummel on 4/4/16.
+//  Copyright © 2016 ianynda. All rights reserved.
+//
+
+import Foundation
+
+extension NSAttributedString {
+	func attributedStringByTrimmingNewlines() -> NSAttributedString {
+		var attributedString = self
+		while attributedString.string.characters.first == "\n" {
+			attributedString = attributedString.attributedSubstringFromRange(NSMakeRange(1, attributedString.string.characters.count - 1))
+		}
+		while attributedString.string.characters.last == "\n" {
+			attributedString = attributedString.attributedSubstringFromRange(NSMakeRange(0, attributedString.string.characters.count - 1))
+		}
+		return attributedString
+	}
+}

--- a/Highball/Post.swift
+++ b/Highball/Post.swift
@@ -75,7 +75,6 @@ class Post {
 			if let trail = json["trail"].array {
 				return trail.map { trailElement -> PostTrailData? in
 					if let name = trailElement["blog"]["name"].string, let content = trailElement["content"].string {
-						print(trailElement)
 						return PostTrailData(username: name, content: content)
 					} else {
 						return nil


### PR DESCRIPTION
This fixes height computation from attributed strings. Some html styles were generating newlines at the start and end of the content. Looks mostly like things of the form <p><p>foo</p><p>bar</p></p>, which seems to convert to \n\nfoo\n\bar.