### PR TITLE
Dispatch table reloads from inline height changes

### DIFF
--- a/Highball/PostsTableViewAdapter.swift
+++ b/Highball/PostsTableViewAdapter.swift
@@ -114,7 +114,9 @@ extension PostsTableViewAdapter: UITableViewDataSource {
 				}
 				if height != self?.postHeightCache.bodyComponentHeightForPost(post, atIndex: indexPath.row - 1, withKey: url) {
 					self?.postHeightCache.setBodyComponentHeight(height, forPost: post, atIndex: indexPath.row - 1, withKey: url)
-					self?.tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .None)
+					dispatch_async(dispatch_get_main_queue()) {
+						self?.tableView.reloadRowsAtIndexPaths([indexPath], withRowAnimation: .Automatic)
+					}
 				}
 
 			}


### PR DESCRIPTION
For some reason doing them synchronously with the DTCoreText async image loads caused the actual height change to delay. This fixes it.