### PR TITLE
Just disable the legacy constructor rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,7 @@ disabled_rules:
         - force_cast
         - force_try
         - variable_name
+        - legacy_constructor
 included:
         - Highball
 line_length: 200


### PR DESCRIPTION
There is no modern constructor for NSRange as far as I can tell.